### PR TITLE
Automatically publish built artifacts to GitHub pages

### DIFF
--- a/.github/workflows/marp.yaml
+++ b/.github/workflows/marp.yaml
@@ -14,6 +14,8 @@ jobs:
         run: docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG marpteam/marp-cli -I marp -o build
       - name: Build PDFs
         run: docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG marpteam/marp-cli -I marp -o build --pdf
+      - name: Build HTML index
+        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><ul>' > index.html && for file in *; do echo "<a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a>" >> index.html; done && echo '</ul>' >> index.html && cd ..
       - name: Create ZIP
         run: mkdir -p staging && zip staging/rechnernetze_tutorium.zip build/*
       - uses: actions/upload-artifact@v1
@@ -27,3 +29,11 @@ jobs:
           automatic_release_tag: latest-pdfs
           files: |
             staging/*
+      - name: Deploy to GitHub pages
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build
+          CLEAN: true

--- a/.github/workflows/marp.yaml
+++ b/.github/workflows/marp.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build PDFs
         run: docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG marpteam/marp-cli -I marp -o build --pdf
       - name: Build HTML index
-        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><ul>' > index.html && for file in *; do echo "<a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a>" >> index.html; done && echo '</ul>' >> index.html && cd ..
+        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css"><h1>Rechnernetze 1 - Tutorium</h1><ul>' > index.html && for file in *; do echo "<li><a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a></li>" >> index.html; done && echo '</ul>' >> index.html && cd ..
       - name: Create ZIP
         run: mkdir -p staging && zip staging/rechnernetze_tutorium.zip build/*
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/marp.yaml
+++ b/.github/workflows/marp.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build PDFs
         run: docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG marpteam/marp-cli -I marp -o build --pdf
       - name: Build HTML index
-        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css"><main><h1>Rechnernetze 1 - Tutorium</h1><ul>' > index.html && for file in *; do echo "<li><a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a></li>" >> index.html; done && echo '</ul></main>' >> index.html && cd ..
+        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css"><main><h1>Rechnernetze 1 - Tutorium</h1><a href="https://github.com/blauwiggle/Rechnernetze-1-Tutorium">📟 Zum Quellcode auf GitHub</a><ul>' > index.html && for file in *; do echo "<li><a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a></li>" >> index.html; done && echo '</ul></main>' >> index.html && cd ..
       - name: Create ZIP
         run: mkdir -p staging && zip staging/rechnernetze_tutorium.zip build/*
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/marp.yaml
+++ b/.github/workflows/marp.yaml
@@ -23,6 +23,7 @@ jobs:
           name: PDFs-and-HTML
           path: staging
       - uses: "marvinpinto/action-automatic-releases@latest"
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: true

--- a/.github/workflows/marp.yaml
+++ b/.github/workflows/marp.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build PDFs
         run: docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG marpteam/marp-cli -I marp -o build --pdf
       - name: Build HTML index
-        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css"><h1>Rechnernetze 1 - Tutorium</h1><ul>' > index.html && for file in *; do echo "<li><a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a></li>" >> index.html; done && echo '</ul>' >> index.html && cd ..
+        run: cd build && echo '<!DOCTYPE html><meta charset="utf-8"><title>Rechnernetze 1 - Tutorium</title><link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css"><main><h1>Rechnernetze 1 - Tutorium</h1><ul>' > index.html && for file in *; do echo "<li><a href=\"/Rechnernetze-1-Tutorium/$file\">$file</a></li>" >> index.html; done && echo '</ul></main>' >> index.html && cd ..
       - name: Create ZIP
         run: mkdir -p staging && zip staging/rechnernetze_tutorium.zip build/*
       - uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 Hallo,
 
-schön das du hier bist. Du musst hier nur noch die Folien herunterladen und dann kann es auch schon los gehen.
+schön das du hier bist. Die aktuellen Folien finden sich immer hier: [blauwiggle.github.io/Rechnernetze-1-Tutorium](https://blauwiggle.github.io/Rechnernetze-1-Tutorium).
 
 ## Download
 
-Einfach diese Addresse besuchen: [blauwiggle.github.io/Rechnernetze-1-Tutorium](https://blauwiggle.github.io/Rechnernetze-1-Tutorium).
-
-Zum Download finden sich hier auch alle Folien als PDF und HTML: [GitHub Releases](https://github.com/blauwiggle/Rechnernetze-1-Tutorium/releases).
+Zum Download finden sich hier auch alle Folien (PDF und HTML) als ZIP-Archiv: [GitHub Releases](https://github.com/blauwiggle/Rechnernetze-1-Tutorium/releases).
 
 ## Git was?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ schön das du hier bist. Du musst hier nur noch die Folien herunterladen und dan
 
 ## Download
 
-Hier finden sich alle Folien als PDF und HTML: [GitHub Releases](https://github.com/blauwiggle/Rechnernetze-1-Tutorium/releases).
+Einfach diese Addresse besuchen: [blauwiggle.github.io/Rechnernetze-1-Tutorium](https://blauwiggle.github.io/Rechnernetze-1-Tutorium).
+
+Zum Download finden sich hier auch alle Folien als PDF und HTML: [GitHub Releases](https://github.com/blauwiggle/Rechnernetze-1-Tutorium/releases).
 
 ## Git was?
 


### PR DESCRIPTION
This PR extends the CI/CD configuration to publish the HTML pages and PDFs to GitHub pages; this way, it is no longer required to manually download them each time and one can also link to them directly. Here is a quick preview (which is being built from my fork): https://pojntfx.github.io/Rechnernetze-1-Tutorium/

In order to activate GitHub pages, the `gh-pages` branch should be selected after accepting this PR and after the GitHub action has run (which will create said branch). The repo settings should be configured like so:

<img width="921" alt="Screenshot 2020-11-13 at 15 29 13" src="https://user-images.githubusercontent.com/28832235/99082870-0786ec80-25c5-11eb-87fd-cccd06f3deac.png">